### PR TITLE
Makes it possible to get the cell template from the Cursor object.

### DIFF
--- a/terminal-emulator/src/term/mod.rs
+++ b/terminal-emulator/src/term/mod.rs
@@ -536,6 +536,10 @@ pub struct Cursor {
     charsets: Charsets,
 }
 
+impl Cursor {
+    pub fn attributes(&self) -> Cell { self.template }
+}
+
 pub struct VisualBell {
     /// Visual bell duration
     duration: Duration,


### PR DESCRIPTION
It would be nice to allow the user of the terminal-emulator crate to know the current attributes (i.e. the attributes that will be used for subsequent output)

