### PR TITLE
Fix #3 UB in terminal-emulator Cell

### DIFF
--- a/terminal-emulator/src/term/cell.rs
+++ b/terminal-emulator/src/term/cell.rs
@@ -124,15 +124,16 @@ impl Cell {
 
     #[inline]
     pub fn chars(&self) -> [char; MAX_ZEROWIDTH_CHARS + 1] {
+        use std::mem::MaybeUninit;
         unsafe {
-            let mut chars = [std::mem::uninitialized(); MAX_ZEROWIDTH_CHARS + 1];
-            std::ptr::write(&mut chars[0], self.c);
+            let mut chars: MaybeUninit<[char; MAX_ZEROWIDTH_CHARS + 1]> = MaybeUninit::uninit();
+            std::ptr::write(chars.as_mut_ptr() as *mut char, self.c);
             std::ptr::copy_nonoverlapping(
                 self.extra.as_ptr(),
-                chars.as_mut_ptr().offset(1),
+                (chars.as_mut_ptr() as *mut char).offset(1),
                 self.extra.len(),
             );
-            chars
+            chars.assume_init()
         }
     }
 


### PR DESCRIPTION
This playground has a minimum sample with the old and new versions: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=230089ed0aad921969f5b72725fb7c07

If you run it under MIRI (Tools->MIRI), the new version seems to pass fine (This does not gurantee it being UB-free, but it's something). The old version is not only detected by MIRI but also statically compiled to a panic by recent rustc